### PR TITLE
Add filters to RIPS patient service resources

### DIFF
--- a/app/Filament/HospitalAdmin/Clusters/Patients/Resources/RipsPatientServiceResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/Patients/Resources/RipsPatientServiceResource.php
@@ -6,8 +6,15 @@ use App\Filament\HospitalAdmin\Clusters\Patients;
 use App\Filament\HospitalAdmin\Clusters\Patients\Resources\RipsPatientServiceResource\Pages;
 use App\Filament\HospitalAdmin\Clusters\Patients\Resources\RipsPatientServiceResource\RelationManagers;
 use App\Models\Rips\RipsPatientService;
+use App\Models\Patient;
+use App\Models\Rips\RipsTenantPayerAgreement;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\Filter;
+use Malzariey\FilamentDaterangepickerFilter\Filters\DateRangeFilter;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -89,7 +96,40 @@ public static function table(Table $table): Table
                 ->label('Fecha de Actualización'),
         ])
         ->filters([
-            // Agregar filtros si es necesario
+            DateRangeFilter::make('service_datetime')
+                ->label('Fecha de Servicio'),
+            SelectFilter::make('agreement_id')
+                ->label('Convenio')
+                ->options(RipsTenantPayerAgreement::pluck('name', 'id'))
+                ->query(function (Builder $query, $value) {
+                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
+                        $subQuery->where('agreement_id', $value);
+                    });
+                }),
+            Filter::make('document_number')
+                ->form([
+                    TextInput::make('document_number')
+                        ->label('Número de Factura'),
+                ])
+                ->query(function (Builder $query, array $data) {
+                    $query->when($data['document_number'], function (Builder $query, $value) {
+                        $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
+                            $subQuery->where('document_number', 'like', "%{$value}%");
+                        });
+                    });
+                }),
+            Filter::make('patient_id')
+                ->form([
+                    Select::make('patient_id')
+                        ->label('Paciente')
+                        ->searchable()
+                        ->options(Patient::getActivePatientNames()->toArray()),
+                ])
+                ->query(function (Builder $query, array $data) {
+                    $query->when($data['patient_id'], function (Builder $query, $value) {
+                        $query->where('patient_id', $value);
+                    });
+                }),
         ])
         ->actions([
             Tables\Actions\ViewAction::make(),

--- a/app/Filament/HospitalAdmin/Clusters/Rips/Resources/RIPSResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/Rips/Resources/RIPSResource.php
@@ -6,8 +6,15 @@ use App\Filament\HospitalAdmin\Clusters\RipsCluster;
 use App\Filament\HospitalAdmin\Clusters\Rips\Resources\RipsResource\Pages;
 use App\Filament\HospitalAdmin\Clusters\Rips\Resources\RipsResource\RelationManagers;
 use App\Models\Rips\RipsPatientService;
+use App\Models\Patient;
+use App\Models\Rips\RipsTenantPayerAgreement;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\Filter;
+use Malzariey\FilamentDaterangepickerFilter\Filters\DateRangeFilter;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -86,7 +93,40 @@ public static function table(Table $table): Table
                 ->label('Fecha de Actualización'),
         ])
         ->filters([
-            // Agregar filtros si es necesario
+            DateRangeFilter::make('service_datetime')
+                ->label('Fecha de Servicio'),
+            SelectFilter::make('agreement_id')
+                ->label('Convenio')
+                ->options(RipsTenantPayerAgreement::pluck('name', 'id'))
+                ->query(function (Builder $query, $value) {
+                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
+                        $subQuery->where('agreement_id', $value);
+                    });
+                }),
+            Filter::make('document_number')
+                ->form([
+                    TextInput::make('document_number')
+                        ->label('Número de Factura'),
+                ])
+                ->query(function (Builder $query, array $data) {
+                    $query->when($data['document_number'], function (Builder $query, $value) {
+                        $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
+                            $subQuery->where('document_number', 'like', "%{$value}%");
+                        });
+                    });
+                }),
+            Filter::make('patient_id')
+                ->form([
+                    Select::make('patient_id')
+                        ->label('Paciente')
+                        ->searchable()
+                        ->options(Patient::getActivePatientNames()->toArray()),
+                ])
+                ->query(function (Builder $query, array $data) {
+                    $query->when($data['patient_id'], function (Builder $query, $value) {
+                        $query->where('patient_id', $value);
+                    });
+                }),
         ])
         ->actions([
             Tables\Actions\ViewAction::make(),


### PR DESCRIPTION
## Summary
- extend RIPSResource with service date, agreement, invoice number and patient filters
- apply the same filters to RipsPatientServiceResource used in the Patients cluster

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861e371e12c8331bf4f0d4c9ee1d6bd