### PR TITLE
Fix agreement filter query callbacks

### DIFF
--- a/app/Filament/HospitalAdmin/Clusters/Patients/Resources/RipsPatientServiceResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/Patients/Resources/RipsPatientServiceResource.php
@@ -101,9 +101,9 @@ public static function table(Table $table): Table
             SelectFilter::make('agreement_id')
                 ->label('Convenio')
                 ->options(RipsTenantPayerAgreement::pluck('name', 'id'))
-                ->query(function (Builder $query, $value) {
-                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
-                        $subQuery->where('agreement_id', $value);
+                ->query(function (Builder $query, $state) {
+                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($state) {
+                        $subQuery->where('agreement_id', $state['value']);
                     });
                 }),
             Filter::make('document_number')

--- a/app/Filament/HospitalAdmin/Clusters/Rips/Resources/RIPSResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/Rips/Resources/RIPSResource.php
@@ -98,9 +98,9 @@ public static function table(Table $table): Table
             SelectFilter::make('agreement_id')
                 ->label('Convenio')
                 ->options(RipsTenantPayerAgreement::pluck('name', 'id'))
-                ->query(function (Builder $query, $value) {
-                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($value) {
-                        $subQuery->where('agreement_id', $value);
+                ->query(function (Builder $query, $state) {
+                    $query->whereHas('billingDocument', function (Builder $subQuery) use ($state) {
+                        $subQuery->where('agreement_id', $state['value']);
                     });
                 }),
             Filter::make('document_number')


### PR DESCRIPTION
## Summary
- update `SelectFilter` query callback signatures to use state

## Testing
- `./vendor/bin/pest --version` *(fails: No such file or directory)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6861ef942c9c833182d01c4ed0f55c0f