### PR TITLE
Move FrontCMS pages to Settings cluster

### DIFF
--- a/app/Filament/HospitalAdmin/Clusters/FrontCms.php
+++ b/app/Filament/HospitalAdmin/Clusters/FrontCms.php
@@ -46,4 +46,9 @@ class FrontCms extends Cluster
         }
         return true;
     }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return false;
+    }
 }

--- a/app/Filament/HospitalAdmin/Clusters/FrontCms/Pages/Cms.php
+++ b/app/Filament/HospitalAdmin/Clusters/FrontCms/Pages/Cms.php
@@ -2,7 +2,7 @@
 
 namespace App\Filament\HospitalAdmin\Clusters\FrontCms\Pages;
 
-use App\Filament\HospitalAdmin\Clusters\FrontCms;
+use App\Filament\HospitalAdmin\Clusters\Settings;
 use Filament\Pages\Page;
 use App\Models\FrontSetting;
 use Filament\Forms\Components\Tabs;
@@ -31,9 +31,9 @@ class Cms extends Page implements HasForms
 
     public ?array $data = [];
 
-    protected static string $view = 'filament.hospital-admin.clusters.front-cms.pages.cms';
+    protected static string $view = 'filament.hospital-admin.clusters.settings.pages.cms';
 
-    protected static ?string $cluster = FrontCms::class;
+    protected static ?string $cluster = Settings::class;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 

--- a/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/FrontCmsServicesResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/FrontCmsServicesResource.php
@@ -11,7 +11,7 @@ use Filament\Forms\Components\Textarea;
 use Illuminate\Database\Eloquent\Model;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\SubNavigationPosition;
-use App\Filament\HospitalAdmin\Clusters\FrontCms;
+use App\Filament\HospitalAdmin\Clusters\Settings;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Filament\HospitalAdmin\Clusters\FrontCms\Resources\FrontCmsServicesResource\Pages;
@@ -21,7 +21,7 @@ class FrontCmsServicesResource extends Resource
 {
     protected static ?string $model = FrontService::class;
 
-    protected static ?string $cluster = FrontCms::class;
+    protected static ?string $cluster = Settings::class;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 

--- a/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/NoticeBoardsResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/NoticeBoardsResource.php
@@ -11,7 +11,7 @@ use App\Models\NoticeBoard;
 use Filament\Resources\Resource;
 use Illuminate\Database\Eloquent\Model;
 use Filament\Pages\SubNavigationPosition;
-use App\Filament\HospitalAdmin\Clusters\FrontCms;
+use App\Filament\HospitalAdmin\Clusters\Settings;
 use App\Filament\HospitalAdmin\Clusters\FrontCms\Resources\NoticeBoardsResource\Pages;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -19,7 +19,7 @@ class NoticeBoardsResource extends Resource
 {
     protected static ?string $model = NoticeBoard::class;
 
-    protected static ?string $cluster = FrontCms::class;
+    protected static ?string $cluster = Settings::class;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 

--- a/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/TestimonialsResource.php
+++ b/app/Filament/HospitalAdmin/Clusters/FrontCms/Resources/TestimonialsResource.php
@@ -12,7 +12,7 @@ use Filament\Forms\Components\Textarea;
 use Illuminate\Database\Eloquent\Model;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\SubNavigationPosition;
-use App\Filament\HospitalAdmin\Clusters\FrontCms;
+use App\Filament\HospitalAdmin\Clusters\Settings;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
 use App\Filament\HospitalAdmin\Clusters\FrontCms\Resources\TestimonialsResource\Pages;
@@ -21,7 +21,7 @@ class TestimonialsResource extends Resource
 {
     protected static ?string $model = Testimonial::class;
 
-    protected static ?string $cluster = FrontCms::class;
+    protected static ?string $cluster = Settings::class;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 

--- a/resources/views/filament/hospital-admin/clusters/settings/pages/cms.blade.php
+++ b/resources/views/filament/hospital-admin/clusters/settings/pages/cms.blade.php
@@ -1,0 +1,6 @@
+<x-filament-panels::page>
+    <x-filament-panels::form>
+        {{ $this->form }}
+        <x-filament-panels::form.actions :actions="$this->getFormActions()" />
+    </x-filament-panels::form>
+</x-filament-panels::page>


### PR DESCRIPTION
## Summary
- link CMS pages to Settings cluster instead of FrontCms
- disable navigation for old FrontCms cluster
- add CMS view under Settings cluster

## Testing
- `composer install --no-interaction --no-progress` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6883fa3e1a948331afff1ddca17fc493