### PR TITLE
Integrate Wompi payment gateway

### DIFF
--- a/app/Models/Subscription.php
+++ b/app/Models/Subscription.php
@@ -60,6 +60,8 @@ class Subscription extends Model
 
     const TYPE_FLUTTERWAVE = 8;
 
+    const TYPE_WOMPI = 9;
+
     const EXPIRED = 0;
 
     const NOT_EXPIRED = 1;
@@ -72,6 +74,7 @@ class Subscription extends Model
         self::TYPE_CASH => 'Manual',
         self::TYPE_PAYTM => 'Paytm',
         self::TYPE_PAYSTACK => 'Paystack',
+        self::TYPE_WOMPI => 'Wompi',
     ];
 
     const STATUS_ARR = [
@@ -96,6 +99,7 @@ class Subscription extends Model
         self::TYPE_PAYSTACK => 'Paystack',
         self::TYPE_PHONEPE => 'PhonePe',
         self::TYPE_FLUTTERWAVE => 'FlutterWave',
+        self::TYPE_WOMPI => 'Wompi',
     ];
 
     const MONTH = 'Month';

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -89,7 +89,9 @@ class Transaction extends Model implements HasMedia
 
     const TYPE_FLUTTERWAVE = 8;
 
-    const ALL = 9;
+    const TYPE_WOMPI = 9;
+
+    const ALL = 10;
 
     const APPROVED = 1;
 
@@ -102,6 +104,7 @@ class Transaction extends Model implements HasMedia
         self::TYPE_CASH => 'Manual',
         self::TYPE_PAYTM => 'Paytm',
         self::TYPE_PAYSTACK => 'Paystack',
+        self::TYPE_WOMPI => 'Wompi',
     ];
 
     const PAYMENT_TYPES_FILTER = [
@@ -114,6 +117,7 @@ class Transaction extends Model implements HasMedia
         self::TYPE_PAYSTACK => 'Paystack',
         self::TYPE_PHONEPE => 'PhonePe',
         self::TYPE_FLUTTERWAVE => 'FlutterWave',
+        self::TYPE_WOMPI => 'Wompi',
     ];
 
     public function user(): BelongsTo


### PR DESCRIPTION
## Summary
- replace PayPal integration with Bancolombia Wompi for subscription purchases
- store Wompi transactions and subscriptions after verifying event signature
- add Wompi payment type constants to Transaction and Subscription models

## Testing
- `php -l app/Http/Controllers/WompiController.php`
- `php -l app/Models/Transaction.php`
- `php -l app/Models/Subscription.php`
- `php artisan test` *(fails: Failed to open stream: No such file or directory)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68968ac0ea34833196df14b2b19f2d68