### PR TITLE
Add Wompi option to super admin payment types

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1007,6 +1007,7 @@ if (!function_exists('getSuperAdminPaymentTypes')) {
         $phonePe = getSuperAdminPaymentCredentials('phonepe_enable');
         $paypal = getSuperAdminPaymentCredentials('paypal_enable');
         $flutterWave = getSuperAdminPaymentCredentials('flutterwave_enable');
+        $wompi = getSuperAdminPaymentCredentials('wompi_enable');
 
         $paymentTypeArray[4] = 'Manual';
 
@@ -1027,6 +1028,9 @@ if (!function_exists('getSuperAdminPaymentTypes')) {
         }
         if (!empty($flutterWave)) {
             $paymentTypeArray[8] = 'FlutterWave';
+        }
+        if (!empty($wompi)) {
+            $paymentTypeArray[9] = 'Wompi';
         }
 
         return $paymentTypeArray;


### PR DESCRIPTION
## Summary
- include Wompi credential check when building Super Admin payment types
- expose Wompi as payment type when enabled

## Testing
- `php -l app/helpers.php`
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68968dca4f5083318e146f6037accd90