### PR TITLE
Add Wompi subscription payment option

### DIFF
--- a/app/Filament/HospitalAdmin/Pages/ChoosePaymentType.php
+++ b/app/Filament/HospitalAdmin/Pages/ChoosePaymentType.php
@@ -75,6 +75,7 @@ class ChoosePaymentType extends Page implements HasForms
         }
         $query = SuperAdminSetting::pluck('value', 'key')->toArray();
         $manualPaymentGuide = $query['manual_instruction'] ?? null;
+        $wompiEndpoint = route('wompi.purchase');
 
         $transction = Transaction::where('user_id', getLoggedInUserId())
             ->where('payment_type', Transaction::TYPE_CASH)
@@ -96,7 +97,7 @@ class ChoosePaymentType extends Page implements HasForms
         }
 
 
-        return compact('plan', 'currentActivePlan', 'manualPaymentGuide');
+        return compact('plan', 'currentActivePlan', 'manualPaymentGuide', 'wompiEndpoint');
     }
 
 

--- a/resources/views/filament/hospital-admin/pages/choose-payment-type.blade.php
+++ b/resources/views/filament/hospital-admin/pages/choose-payment-type.blade.php
@@ -283,6 +283,24 @@
                             </x-filament::button>
                             {{-- @endif --}}
                         </div>
+                    @elseif ($paymentType == 9)
+                        <form action="{{ $wompiEndpoint }}" method="POST" class="flex justify-center">
+                            @csrf
+                            <input type="hidden" name="plan" value="{{ $plan }}">
+                            <div class="pt-4">
+                                <x-filament::button wire:loading.attr="disabled" type="submit" class="px-4">
+                                    <span class="flex justify-center">
+                                        <svg wire:loading aria-hidden="true" role="status" class="hidden inline w-4 h-4 my-auto text-white me-1 animate-spin" viewBox="0 0 100 101" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                            <path d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z" fill="#E5E7EB" />
+                                            <path d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z" fill="currentColor" />
+                                        </svg>
+                                        <span class="ms-1">
+                                            {{ __('messages.subscription_plans.pay_or_switch_plan') }}
+                                        </span>
+                                    </span>
+                                </x-filament::button>
+                            </div>
+                        </form>
                     @elseif ($paymentType == 8)
                         <form action="{{ route('flutterwave.subscription') }}" method="get"
                             class="flex justify-center">
@@ -344,6 +362,9 @@
         @endif
     </div>
 </section>
+@if ($paymentType == 9)
+    <script src="https://checkout.wompi.co/widget.js" async></script>
+@endif
 {{-- <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://checkout.razorpay.com/v1/checkout.js"></script>
 


### PR DESCRIPTION
## Summary
- Expose Wompi purchase endpoint to the payment selection page
- Add Wompi form submission and widget script when chosen

## Testing
- `composer test` *(fails: Command "test" is not defined.)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689690b8fcb8833190a343d9c8063ffe