### PR TITLE
Add Filament resource to manage RIPS statuses

### DIFF
--- a/app/Filament/Clusters/Settings/Resources/RipsStatusResource.php
+++ b/app/Filament/Clusters/Settings/Resources/RipsStatusResource.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Filament\Clusters\Settings\Resources;
+
+use App\Filament\Clusters\Settings;
+use App\Filament\Clusters\Settings\Resources\RipsStatusResource\Pages;
+use App\Models\Rips\RipsStatus;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Pages\SubNavigationPosition;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class RipsStatusResource extends Resource
+{
+    protected static ?string $model = RipsStatus::class;
+
+    protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
+
+    protected static ?int $navigationSort = 7;
+
+    protected static ?string $cluster = Settings::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name')
+                    ->label(__('messages.common.name'))
+                    ->required()
+                    ->maxLength(255)
+                    ->unique('rips_statuses', 'name', ignoreRecord: true),
+                Forms\Components\Textarea::make('description')
+                    ->label(__('messages.common.description'))
+                    ->columnSpanFull(),
+            ])
+            ->columns(1);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('name')
+                    ->label(__('messages.common.name'))
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('description')
+                    ->label(__('messages.common.description'))
+                    ->limit(70)
+                    ->wrap(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->label(__('messages.common.created_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label(__('messages.common.updated_at'))
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListRipsStatuses::route('/'),
+            'create' => Pages\CreateRipsStatus::route('/create'),
+            'view' => Pages\ViewRipsStatus::route('/{record}'),
+            'edit' => Pages\EditRipsStatus::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/CreateRipsStatus.php
+++ b/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/CreateRipsStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Clusters\Settings\Resources\RipsStatusResource\Pages;
+
+use App\Filament\Clusters\Settings\Resources\RipsStatusResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateRipsStatus extends CreateRecord
+{
+    protected static string $resource = RipsStatusResource::class;
+}

--- a/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/EditRipsStatus.php
+++ b/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/EditRipsStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Clusters\Settings\Resources\RipsStatusResource\Pages;
+
+use App\Filament\Clusters\Settings\Resources\RipsStatusResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditRipsStatus extends EditRecord
+{
+    protected static string $resource = RipsStatusResource::class;
+}

--- a/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/ListRipsStatuses.php
+++ b/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/ListRipsStatuses.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Clusters\Settings\Resources\RipsStatusResource\Pages;
+
+use App\Filament\Clusters\Settings\Resources\RipsStatusResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListRipsStatuses extends ListRecords
+{
+    protected static string $resource = RipsStatusResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/ViewRipsStatus.php
+++ b/app/Filament/Clusters/Settings/Resources/RipsStatusResource/Pages/ViewRipsStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Clusters\Settings\Resources\RipsStatusResource\Pages;
+
+use App\Filament\Clusters\Settings\Resources\RipsStatusResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewRipsStatus extends ViewRecord
+{
+    protected static string $resource = RipsStatusResource::class;
+}


### PR DESCRIPTION
## Summary
- add a Filament resource within the Settings cluster to manage entries in the `rips_statuses` table
- provide list, create, edit, and view pages for RIPS statuses with validation and table enhancements

## Testing
- `php artisan test` *(fails: vendor dependencies are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1ff5b5d08331babe4e90c972f5bb