### PR TITLE
Fix CIE10 super admin resource model namespace

### DIFF
--- a/app/Filament/Clusters/Settings/Resources/Cie10Resource.php
+++ b/app/Filament/Clusters/Settings/Resources/Cie10Resource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Clusters\Settings\Resources;
 use App\Filament\Clusters\Settings;
 use App\Filament\Clusters\Settings\Resources\Cie10Resource\Pages;
 use App\Filament\Clusters\Settings\Resources\Cie10Resource\RelationManagers;
-use App\Models\Cie10;
+use App\Models\Rips\Cie10;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;


### PR DESCRIPTION
## Summary
- update the CIE10 settings resource to reference the existing App\\Models\\Rips\\Cie10 model so the super admin panel can load the records

## Testing
- php artisan test *(fails: missing vendor dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2cf52cf8833183541483d48a6597