### PR TITLE
Fix CIE10 and CUPS super admin resource model namespaces

### DIFF
--- a/app/Filament/Clusters/Settings/Resources/Cie10Resource.php
+++ b/app/Filament/Clusters/Settings/Resources/Cie10Resource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Clusters\Settings\Resources;
 use App\Filament\Clusters\Settings;
 use App\Filament\Clusters\Settings\Resources\Cie10Resource\Pages;
 use App\Filament\Clusters\Settings\Resources\Cie10Resource\RelationManagers;
-use App\Models\Cie10;
+use App\Models\Rips\Cie10;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;

--- a/app/Filament/Clusters/Settings/Resources/CupsResource.php
+++ b/app/Filament/Clusters/Settings/Resources/CupsResource.php
@@ -5,7 +5,7 @@ namespace App\Filament\Clusters\Settings\Resources;
 use App\Filament\Clusters\Settings;
 use App\Filament\Clusters\Settings\Resources\CupsResource\Pages;
 use App\Filament\Clusters\Settings\Resources\CupsResource\RelationManagers;
-use App\Models\RipsCups;
+use App\Models\Rips\RipsCups;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -17,7 +17,7 @@ use Filament\Pages\SubNavigationPosition;
 
 class CupsResource extends Resource
 {
-    protected static ?string $model = Cups::class;
+    protected static ?string $model = RipsCups::class;
 
     protected static SubNavigationPosition $subNavigationPosition = SubNavigationPosition::Top;
 


### PR DESCRIPTION
## Summary
- update the CIE10 settings resource to reference the existing App\Models\Rips\Cie10 model so the super admin panel can load the records
- point the CUPS settings resource at the App\Models\Rips\RipsCups model to avoid class resolution errors when loading that page

## Testing
- php artisan test *(fails: missing vendor dependencies in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce2cf52cf8833183541483d48a6597